### PR TITLE
feat(notifications): Añadir visualización de mapa para alertas sísmicas

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -129,9 +129,7 @@
             <div id="air-quality-modal-body" class="sec-modal-body"></div>
         </div>
     </div>
-    <div id="air-quality-modal" class="sec-modal-overlay" style="display: none;">
-    </div>
-
+    
     <div id="event-map-popup" class="event-map-overlay">
         <div class="event-map-content">
             <div class="event-map-header">

--- a/dashboard.html
+++ b/dashboard.html
@@ -129,5 +129,16 @@
             <div id="air-quality-modal-body" class="sec-modal-body"></div>
         </div>
     </div>
+    <div id="air-quality-modal" class="sec-modal-overlay" style="display: none;">
+    </div>
+
+    <div id="event-map-popup" class="event-map-overlay">
+        <div class="event-map-content">
+            <div class="event-map-header">
+                <h3>Ubicación del Evento Sísmico</h3>
+            </div>
+            <div id="event-map-container"></div>
+        </div>
+    </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -2972,3 +2972,65 @@ footer {
     font-weight: bold;
     color: #0277bd;
 }
+
+/* --- ESTILOS PARA POPUP DE MAPA DE EVENTOS SÍSMICOS --- */
+.event-map-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9998; /* Muy alto, pero por debajo de otros modales si es necesario */
+    backdrop-filter: blur(5px);
+    
+    /* Control de visibilidad y animación */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.5s ease-in-out, visibility 0.5s;
+}
+
+.event-map-overlay.visible {
+    opacity: 1;
+    visibility: visible;
+}
+
+.event-map-content {
+    background-color: #ffffff;
+    width: 50%;
+    height: 50%;
+    border-radius: 10px;
+    box-shadow: 0 5px 25px rgba(0,0,0,0.4);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden; /* Asegura que las esquinas redondeadas se apliquen al mapa */
+    transform: scale(0.95);
+    transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.event-map-overlay.visible .event-map-content {
+    transform: scale(1);
+}
+
+.event-map-header {
+    background-color: #c20d00;
+    color: white;
+    padding: 10px 15px;
+    flex-shrink: 0; /* Evita que el header se encoja */
+}
+
+.event-map-header h3 {
+    margin: 0;
+    font-size: 1.3em;
+    text-align: center;
+    color: white;
+    border: none;
+}
+
+#event-map-container {
+    flex-grow: 1; /* Hace que el mapa ocupe todo el espacio restante */
+    background-color: #e5e3df; /* Color de fondo mientras carga el mapa */
+}


### PR DESCRIPTION
Implementa una nueva funcionalidad que mejora la conciencia situacional durante alertas sísmicas (GEOFON/PTWC) mostrando un mapa emergente con la ubicación del evento.

El popup aparece en el dashboard cuando se inicia la notificación por voz y se desvanece automáticamente una vez que el mensaje ha sido leído por completo.

Cambios implementados:

1.  **Backend (`simple_server.py`):**
    -   Se actualizaron las funciones `_check_tsunami_bulletin` y `_check_geofon_bulletin` para extraer y añadir las coordenadas `lat` y `lon` a la respuesta JSON de las APIs `/api/tsunami_check` y `/api/geofon_check`.

2.  **Frontend (`dashboard.html` y `style.css`):**
    -   Se ha añadido un nuevo contenedor modal (`#event-map-popup`) al final del `<body>` para el mapa.
    -   Se han agregado estilos CSS para que el popup se superponga, ocupe el 50% de la pantalla, esté centrado y tenga animaciones de entrada y salida suaves (fade/scale).

3.  **Frontend (`dashboard.js`):**
    -   Se ha modificado la función `lanzarNotificacion` para que acepte las coordenadas y orqueste la visualización del mapa.
    -   La función `hablar` ahora acepta un `onEndCallback` para poder ejecutar una acción (ocultar el mapa) precisamente cuando la síntesis de voz termina.
    -   Se crearon las funciones `showEventMap` y `hideEventMap` que manejan la lógica del mapa, incluyendo la inicialización única de Leaflet para optimizar el rendimiento.