### PR TITLE
fix(core): Soluciona errores en la vista móvil y mejora el mapa del dashboard

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -382,7 +382,7 @@ document.addEventListener('DOMContentLoaded', () => {
         eventMapPopup.classList.add('visible');
 
         if (!eventMap) { // Inicializa el mapa solo la primera vez
-            eventMap = L.map('event-map-container').setView([lat, lon], 6);
+            eventMap = L.map('event-map-container').setView([lat, lon], 4);
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(eventMap);
             eventMarker = L.marker([lat, lon]).addTo(eventMap)
                 .bindPopup('Ubicación aproximada del evento')

--- a/simple_server.py
+++ b/simple_server.py
@@ -1328,7 +1328,7 @@ class SimpleHttpRequestHandler(BaseHTTPRequestHandler):
                 return
 
             elif requested_path == '/api/last_tsunami_message':
-                LAST_MESSAGE_FILE = os.path.join(DATA_FOLDER_PATH, 'last_tsunami_message.json')
+                LAST_MESSAGE_FILE = os.path.join(DATA_OUTPUT_FOLDER, 'last_tsunami_message.json')
                 if os.path.exists(LAST_MESSAGE_FILE):
                     with open(LAST_MESSAGE_FILE, 'r') as f:
                         data = json.load(f)
@@ -1353,7 +1353,7 @@ class SimpleHttpRequestHandler(BaseHTTPRequestHandler):
                 return
 
             elif requested_path == '/api/last_geofon_message':
-                LAST_MESSAGE_FILE = os.path.join(DATA_FOLDER_PATH, 'last_geofon_message.json')
+                LAST_MESSAGE_FILE = os.path.join(DATA_OUTPUT_FOLDER, 'last_geofon_message.json')
                 if os.path.exists(LAST_MESSAGE_FILE):
                     with open(LAST_MESSAGE_FILE, 'r') as f:
                         data = json.load(f)

--- a/version_mobil/mobile.js
+++ b/version_mobil/mobile.js
@@ -696,17 +696,17 @@ document.addEventListener('DOMContentLoaded', () => {
             modalBody.innerHTML = `
                 <div class="turno-card">
                     <h3>Profesional a Llamado</h3>
-                    <p>${personal[turnoActivo.llamado] || 'No definido'}</p>
+                    <p>${simplificarNombre(personal[turnoActivo.llamado]?.nombre) || 'No definido'}</p>
                 </div>
                 <div class="turno-card">
                     <h3>Personal en Turno (${tipoTurno})</h3>
-                    <p>${personal[turnoActivo.op1] || 'No definido'}</p>
-                    <p>${personal[turnoActivo.op2] || 'No definido'}</p>
+                    <p>${simplificarNombre(personal[turnoActivo.op1]?.nombre) || 'No definido'}</p>
+                    <p>${simplificarNombre(personal[turnoActivo.op2]?.nombre) || 'No definido'}</p>
                 </div>
                 <div class="turno-card">
                     <h3>Próximo Turno</h3>
-                    <p>${proximoTurno ? (personal[proximoTurno.op1] || 'No definido') : 'No definido'}</p>
-                    <p>${proximoTurno ? (personal[proximoTurno.op2] || 'No definido') : 'No definido'}</p>
+                    <p>${proximoTurno ? (simplificarNombre(personal[proximoTurno.op1]?.nombre) || 'No definido') : 'No definido'}</p>
+                    <p>${proximoTurno ? (simplificarNombre(personal[proximoTurno.op2]?.nombre) || 'No definido') : 'No definido'}</p>
                 </div>
             `;
 


### PR DESCRIPTION
fix(app): Corrige visualización en móvil y ajusta zoom de mapa

Este commit soluciona tres problemas identificados:
- Se corrige el error que mostraba `[object Object]` para el personal de turno en la versión móvil.
- Se repara la conexión a los boletines sísmicos (PTWC/GEOFON) en la vista móvil, que fallaba por un error en el servidor.
- Se ajusta el zoom por defecto del mapa de eventos en el dashboard para ofrecer una vista continental más amplia.
